### PR TITLE
chore: Removes references to deprecated availability_hidden

### DIFF
--- a/src/gravity/Artwork.ts
+++ b/src/gravity/Artwork.ts
@@ -107,7 +107,6 @@ export const Artwork = R.Record({
       editions: R.String,
       display_price_currency: R.String,
       availability: R.String,
-      availability_hidden: R.Boolean,
     })
   ),
   cultural_makers: R.Array(
@@ -163,7 +162,6 @@ export const Artwork = R.Record({
   price: R.String,
   series: R.Null.Or(R.String),
   availability: R.String,
-  availability_hidden: R.Boolean,
   ecommerce: R.Boolean,
   offer: R.Boolean,
   tags: R.Array(R.String),

--- a/src/gravity/EditionSet.ts
+++ b/src/gravity/EditionSet.ts
@@ -13,7 +13,6 @@ export const EditionSet = Record({
   editions: String,
   display_price_currency: String,
   availability: String,
-  availability_hidden: Boolean,
 });
 
 export type EditionSet = Static<typeof EditionSet>;


### PR DESCRIPTION
We are deprecating the concept of `availability_hidden` on Artwork and EditionSet

https://artsyproduct.atlassian.net/browse/PX-5027